### PR TITLE
Add URLs to description

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,11 +29,203 @@ authors:
 - family-names: Montenegro
   given-names: Juan F.
   email: jf.montenegro@uniandes.edu.co
+repository-code: https://github.com/epiverse-trace/ColOpenData
+url: https://epiverse-trace.github.io/ColOpenData/
 contact:
 - family-names: Tavera Cifuentes
   given-names: Maria Camila
   email: mc.tavera@uniandes.edu.co
+keywords:
+- colombia
+- data-package
+- r
+- r-package
+- socio-economic-indicators
 references:
+- type: software
+  title: 'R: A Language and Environment for Statistical Computing'
+  notes: Depends
+  url: https://www.R-project.org/
+  authors:
+  - name: R Core Team
+  location:
+    name: Vienna, Austria
+  year: '2024'
+  institution:
+    name: R Foundation for Statistical Computing
+  version: '>= 3.2.0'
+- type: software
+  title: checkmate
+  abstract: 'checkmate: Fast and Versatile Argument Checks'
+  notes: Imports
+  url: https://mllg.github.io/checkmate/
+  repository: https://CRAN.R-project.org/package=checkmate
+  authors:
+  - family-names: Lang
+    given-names: Michel
+    email: michellang@gmail.com
+    orcid: https://orcid.org/0000-0001-9754-0393
+  year: '2024'
+- type: software
+  title: config
+  abstract: 'config: Manage Environment Specific Configuration Values'
+  notes: Imports
+  url: https://rstudio.github.io/config/
+  repository: https://CRAN.R-project.org/package=config
+  authors:
+  - family-names: Allaire
+    given-names: JJ
+    email: jj@rstudio.com
+  year: '2024'
+- type: software
+  title: dplyr
+  abstract: 'dplyr: A Grammar of Data Manipulation'
+  notes: Imports
+  url: https://dplyr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=dplyr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: François
+    given-names: Romain
+    orcid: https://orcid.org/0000-0002-2444-4226
+  - family-names: Henry
+    given-names: Lionel
+  - family-names: Müller
+    given-names: Kirill
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Vaughan
+    given-names: Davis
+    email: davis@posit.co
+    orcid: https://orcid.org/0000-0003-4777-038X
+  year: '2024'
+- type: software
+  title: httr
+  abstract: 'httr: Tools for Working with URLs and HTTP'
+  notes: Imports
+  url: https://httr.r-lib.org/
+  repository: https://CRAN.R-project.org/package=httr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2024'
+- type: software
+  title: lubridate
+  abstract: 'lubridate: Make Dealing with Dates a Little Easier'
+  notes: Imports
+  url: https://lubridate.tidyverse.org
+  repository: https://CRAN.R-project.org/package=lubridate
+  authors:
+  - family-names: Spinu
+    given-names: Vitalie
+    email: spinuvit@gmail.com
+  - family-names: Grolemund
+    given-names: Garrett
+  - family-names: Wickham
+    given-names: Hadley
+  year: '2024'
+- type: software
+  title: magrittr
+  abstract: 'magrittr: A Forward-Pipe Operator for R'
+  notes: Imports
+  url: https://magrittr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=magrittr
+  authors:
+  - family-names: Bache
+    given-names: Stefan Milton
+    email: stefan@stefanbache.dk
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@rstudio.com
+  year: '2024'
+- type: software
+  title: readr
+  abstract: 'readr: Read Rectangular Text Data'
+  notes: Imports
+  url: https://readr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=readr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  - family-names: Hester
+    given-names: Jim
+  - family-names: Bryan
+    given-names: Jennifer
+    email: jenny@posit.co
+    orcid: https://orcid.org/0000-0002-6983-2759
+  year: '2024'
+- type: software
+  title: readxl
+  abstract: 'readxl: Read Excel Files'
+  notes: Imports
+  url: https://readxl.tidyverse.org
+  repository: https://CRAN.R-project.org/package=readxl
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: Bryan
+    given-names: Jennifer
+    email: jenny@posit.co
+    orcid: https://orcid.org/0000-0002-6983-2759
+  year: '2024'
+- type: software
+  title: rlang
+  abstract: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
+  notes: Imports
+  url: https://rlang.r-lib.org
+  repository: https://CRAN.R-project.org/package=rlang
+  authors:
+  - family-names: Henry
+    given-names: Lionel
+    email: lionel@posit.co
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2024'
+- type: software
+  title: sf
+  abstract: 'sf: Simple Features for R'
+  notes: Imports
+  url: https://r-spatial.github.io/sf/
+  repository: https://CRAN.R-project.org/package=sf
+  authors:
+  - family-names: Pebesma
+    given-names: Edzer
+    email: edzer.pebesma@uni-muenster.de
+    orcid: https://orcid.org/0000-0001-8049-7069
+  year: '2024'
+- type: software
+  title: tibble
+  abstract: 'tibble: Simple Data Frames'
+  notes: Imports
+  url: https://tibble.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=tibble
+  authors:
+  - family-names: Müller
+    given-names: Kirill
+    email: kirill@cynkra.com
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@rstudio.com
+  year: '2024'
+- type: software
+  title: utils
+  abstract: 'R: A Language and Environment for Statistical Computing'
+  notes: Imports
+  authors:
+  - name: R Core Team
+  location:
+    name: Vienna, Austria
+  year: '2024'
+  institution:
+    name: R Foundation for Statistical Computing
 - type: software
   title: ggplot2
   abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
@@ -70,6 +262,18 @@ references:
     orcid: https://orcid.org/0000-0002-9415-4582
   year: '2024'
 - type: software
+  title: knitr
+  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
+  notes: Suggests
+  url: https://yihui.org/knitr/
+  repository: https://CRAN.R-project.org/package=knitr
+  authors:
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  year: '2024'
+- type: software
   title: leaflet
   abstract: 'leaflet: Create Interactive Web Maps with the JavaScript ''Leaflet''
     Library'
@@ -88,18 +292,6 @@ references:
     given-names: Bhaskar
   - family-names: Xie
     given-names: Yihui
-  year: '2024'
-- type: software
-  title: knitr
-  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
-  notes: Suggests
-  url: https://yihui.org/knitr/
-  repository: https://CRAN.R-project.org/package=knitr
-  authors:
-  - family-names: Xie
-    given-names: Yihui
-    email: xie@yihui.name
-    orcid: https://orcid.org/0000-0003-0645-5666
   year: '2024'
 - type: software
   title: RColorBrewer
@@ -181,187 +373,3 @@ references:
     email: hadley@posit.co
   year: '2024'
   version: '>= 3.0.0'
-- type: software
-  title: checkmate
-  abstract: 'checkmate: Fast and Versatile Argument Checks'
-  notes: Imports
-  url: https://mllg.github.io/checkmate/
-  repository: https://CRAN.R-project.org/package=checkmate
-  authors:
-  - family-names: Lang
-    given-names: Michel
-    email: michellang@gmail.com
-    orcid: https://orcid.org/0000-0001-9754-0393
-  year: '2024'
-- type: software
-  title: config
-  abstract: 'config: Manage Environment Specific Configuration Values'
-  notes: Imports
-  url: https://rstudio.github.io/config/
-  repository: https://CRAN.R-project.org/package=config
-  authors:
-  - family-names: Allaire
-    given-names: JJ
-    email: jj@rstudio.com
-  year: '2024'
-- type: software
-  title: httr
-  abstract: 'httr: Tools for Working with URLs and HTTP'
-  notes: Imports
-  url: https://httr.r-lib.org/
-  repository: https://CRAN.R-project.org/package=httr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  year: '2024'
-- type: software
-  title: magrittr
-  abstract: 'magrittr: A Forward-Pipe Operator for R'
-  notes: Imports
-  url: https://magrittr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=magrittr
-  authors:
-  - family-names: Bache
-    given-names: Stefan Milton
-    email: stefan@stefanbache.dk
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@rstudio.com
-  year: '2024'
-- type: software
-  title: readxl
-  abstract: 'readxl: Read Excel Files'
-  notes: Imports
-  url: https://readxl.tidyverse.org
-  repository: https://CRAN.R-project.org/package=readxl
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: Bryan
-    given-names: Jennifer
-    email: jenny@posit.co
-    orcid: https://orcid.org/0000-0002-6983-2759
-  year: '2024'
-- type: software
-  title: rlang
-  abstract: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
-  notes: Imports
-  url: https://rlang.r-lib.org
-  repository: https://CRAN.R-project.org/package=rlang
-  authors:
-  - family-names: Henry
-    given-names: Lionel
-    email: lionel@posit.co
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  year: '2024'
-- type: software
-  title: sf
-  abstract: 'sf: Simple Features for R'
-  notes: Imports
-  url: https://r-spatial.github.io/sf/
-  repository: https://CRAN.R-project.org/package=sf
-  authors:
-  - family-names: Pebesma
-    given-names: Edzer
-    email: edzer.pebesma@uni-muenster.de
-    orcid: https://orcid.org/0000-0001-8049-7069
-  year: '2024'
-- type: software
-  title: utils
-  abstract: 'R: A Language and Environment for Statistical Computing'
-  notes: Imports
-  authors:
-  - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2024'
-  institution:
-    name: R Foundation for Statistical Computing
-- type: software
-  title: lubridate
-  abstract: 'lubridate: Make Dealing with Dates a Little Easier'
-  notes: Imports
-  url: https://lubridate.tidyverse.org
-  repository: https://CRAN.R-project.org/package=lubridate
-  authors:
-  - family-names: Spinu
-    given-names: Vitalie
-    email: spinuvit@gmail.com
-  - family-names: Grolemund
-    given-names: Garrett
-  - family-names: Wickham
-    given-names: Hadley
-  year: '2024'
-- type: software
-  title: readr
-  abstract: 'readr: Read Rectangular Text Data'
-  notes: Imports
-  url: https://readr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=readr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  - family-names: Hester
-    given-names: Jim
-  - family-names: Bryan
-    given-names: Jennifer
-    email: jenny@posit.co
-    orcid: https://orcid.org/0000-0002-6983-2759
-  year: '2024'
-- type: software
-  title: dplyr
-  abstract: 'dplyr: A Grammar of Data Manipulation'
-  notes: Imports
-  url: https://dplyr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=dplyr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: François
-    given-names: Romain
-    orcid: https://orcid.org/0000-0002-2444-4226
-  - family-names: Henry
-    given-names: Lionel
-  - family-names: Müller
-    given-names: Kirill
-    orcid: https://orcid.org/0000-0002-1416-3412
-  - family-names: Vaughan
-    given-names: Davis
-    email: davis@posit.co
-    orcid: https://orcid.org/0000-0003-4777-038X
-  year: '2024'
-- type: software
-  title: tibble
-  abstract: 'tibble: Simple Data Frames'
-  notes: Imports
-  url: https://tibble.tidyverse.org/
-  repository: https://CRAN.R-project.org/package=tibble
-  authors:
-  - family-names: Müller
-    given-names: Kirill
-    email: kirill@cynkra.com
-    orcid: https://orcid.org/0000-0002-1416-3412
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@rstudio.com
-  year: '2024'
-- type: software
-  title: 'R: A Language and Environment for Statistical Computing'
-  notes: Depends
-  url: https://www.R-project.org/
-  authors:
-  - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2024'
-  institution:
-    name: R Foundation for Statistical Computing
-  version: '>= 3.2.0'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,51 +2,55 @@ Package: ColOpenData
 Title: ColOpenData
 Version: 0.0.1
 Authors@R: c(
-    person(given = "Maria Camila", family = "Tavera Cifuentes", , email = "mc.tavera@uniandes.edu.co", role = c("aut", "cre")),
-    person(given = "Julian", family = "Otero", , email = "jd.otero10@uniandes.org", role = c("aut")),
-    person(given = "Juan D.", family = "Umana", , email = "jd.umana10@uniandes.edu.co", role = c("aut")),
-    person(given = "Juan F.", family = "Montenegro", , email = "jf.montenegro@uniandes.edu.co", role = c("aut")),
-    person(given = "Juan Manuel", family = "Cordovez", , email = "jucordov@uniandes.edu.co", role = c("ctb")),
-    person(given = "Catalina", family = "Gonzalez Uribe", , email = "cgonzalez@uniandes.edu.co", role = c("ctb")),
-    person(given = "Mauricio", family = "Santos-Vega", , email = "om.santos@uniandes.edu.co", role = c("ctb"))
+    person("Maria Camila", "Tavera Cifuentes", , "mc.tavera@uniandes.edu.co", role = c("aut", "cre")),
+    person("Julian", "Otero", , "jd.otero10@uniandes.org", role = "aut"),
+    person("Juan D.", "Umana", , "jd.umana10@uniandes.edu.co", role = "aut"),
+    person("Juan F.", "Montenegro", , "jf.montenegro@uniandes.edu.co", role = "aut"),
+    person("Juan Manuel", "Cordovez", , "jucordov@uniandes.edu.co", role = "ctb"),
+    person("Catalina", "Gonzalez Uribe", , "cgonzalez@uniandes.edu.co", role = "ctb"),
+    person("Mauricio", "Santos-Vega", , "om.santos@uniandes.edu.co", role = "ctb")
   )
-Description: ColOpenData is a package that acquires, standardizes, and wrangles Colombian
-    socioeconomic, climate and land cover data. It solves the problem of
-    Colombian data being issued in different web pages and formats by using functions that
-    allow the user to select the desired database and download it without having to do the
-    exhausting acquisition process. Also, it allows these datasets to be merged so multiple
-    operations, such as calculating statistics, can be made, taking into account information
-    from different datasets.  
+Description: ColOpenData is a package that acquires, standardizes, and
+    wrangles Colombian socioeconomic, climate and land cover data. It
+    solves the problem of Colombian data being issued in different web
+    pages and formats by using functions that allow the user to select the
+    desired database and download it without having to do the exhausting
+    acquisition process. Also, it allows these datasets to be merged so
+    multiple operations, such as calculating statistics, can be made,
+    taking into account information from different datasets.
 License: MIT + file LICENSE
-Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+URL: https://github.com/epiverse-trace/ColOpenData,
+    https://epiverse-trace.github.io/ColOpenData/
+BugReports: https://github.com/epiverse-trace/ColOpenData/issues
+Depends: 
+    R (>= 3.2.0)
+Imports: 
+    checkmate,
+    config,
+    dplyr,
+    httr,
+    lubridate,
+    magrittr,
+    readr,
+    readxl,
+    rlang,
+    sf,
+    tibble,
+    utils
 Suggests: 
     ggplot2,
-    leaflet,
     knitr,
+    leaflet,
     RColorBrewer,
     rmarkdown,
     spelling,
     testthat (>= 3.0.0)
+VignetteBuilder: 
+    knitr
+Config/Needs/website:epiverse-trace/epiversetheme
 Config/testthat/edition: 3
-Config/Needs/website:
-    epiverse-trace/epiversetheme
+Encoding: UTF-8
 Language: en-US
-Imports: 
-    checkmate,
-    config,
-    httr,
-    magrittr,
-    readxl,
-    rlang,
-    sf,
-    utils,
-    lubridate,
-    readr,
-    dplyr,
-    tibble
-VignetteBuilder: knitr
-Depends: 
-    R (>= 3.2.0)
 LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.3


### PR DESCRIPTION
This PR adds the relevant URLs to the `DESCRIPTION` file to help find the relevant information. This will also help the website generate links to the repository directly. At the same time I also cleaned up the description file using `usethis::use_tidy_description()` to standardize the ordering.

I detected this while familiarizing myself with the package 😊 

